### PR TITLE
Ensure SQLite DB closes on app shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -712,6 +712,16 @@ async function sendMissingFiles(deviceId) {
 }
 
 app.on('before-quit', () => {
+  if (db) {
+    db.close((err) => {
+      if (err) {
+        console.error('Error closing database:', err.message);
+      } else {
+        console.log('Database connection closed.');
+      }
+    });
+  }
+
   bonjour.unpublishAll(() => {
     bonjour.destroy();
   });


### PR DESCRIPTION
## Summary
- persist sqlite database handle for reuse
- close the database in the `before-quit` handler with error logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689608e4bfac832da5f461bbc91b593f