### PR TITLE
refactor: export car ID helper and add CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "package-win": "electron-packager . Pacenote Sync --platform=win32 --arch=x64 --out=release-builds --icon=assets/icon.ico",
     "dist": "electron-builder --win",
     "build": "electron-builder",
-    "test": "node --test"
+    "test": "node --test",
+    "read-car-id": "node readCarIdCli.js"
   },
   "build": {
     "appId": "pacenotesync.app.id",

--- a/readCarId.js
+++ b/readCarId.js
@@ -6,6 +6,11 @@ const ini = require('ini');
  * @param {string} carsIniPath - Path to the Cars.ini file
  * @param {number} slotId - The slot ID (e.g., 5)
  * @returns {object} - JSON with the CarId if found or an error message
+ *
+ * Example:
+ * const { getRSFCarID } = require('./readCarId');
+ * const result = getRSFCarID('E:/Richard Burns Rally/Cars/Cars.ini', 5);
+ * console.log(result);
  */
 function getRSFCarID(carsIniPath, slotId) {
     if (!fs.existsSync(carsIniPath)) {
@@ -30,14 +35,4 @@ function getRSFCarID(carsIniPath, slotId) {
     return { CarId: parseInt(config[section].RSFCarID, 10) };
 }
 
-// Example usage
-function main() {
-    const carsIniPath = 'E:/Richard Burns Rally/Cars/Cars.ini'; // Adjust the path as needed
-    const slotId = 5; // Replace with the slot ID you want to query
-
-    const result = getRSFCarID(carsIniPath, slotId);
-    console.log(JSON.stringify(result, null, 2));
-}
-
-// Run the example
-main();
+module.exports = { getRSFCarID };

--- a/readCarIdCli.js
+++ b/readCarIdCli.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// CLI entry point for retrieving the RSFCarID for a given car slot.
+// Usage: node readCarIdCli.js <path_to_Cars.ini> <slotId>
+const { getRSFCarID } = require('./readCarId');
+
+function usage() {
+  console.log('Usage: node readCarIdCli.js <path_to_Cars.ini> <slotId>');
+}
+
+const [, , carsIniPath, slotId] = process.argv;
+
+if (!carsIniPath || !slotId) {
+  usage();
+  process.exit(1);
+}
+
+const result = getRSFCarID(carsIniPath, parseInt(slotId, 10));
+console.log(JSON.stringify(result, null, 2));
+


### PR DESCRIPTION
## Summary
- export `getRSFCarID` from `readCarId.js` and provide inline example
- add `readCarIdCli.js` for command line use
- expose CLI through a `read-car-id` npm script

## Testing
- `npm test`
- `node readCarIdCli.js /tmp/doesnotexist.ini 5`


------
https://chatgpt.com/codex/tasks/task_e_689608e3b450832d99cbef6e23a68500